### PR TITLE
Create README in permissive-script-security-plugin repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# permissive-script-security-plugin
+Permissive Script Security Plugin
+
+Turn on permissive mode of Script Security Plugin. Problematic
+signatures will be logged but access will not be rejected.
+
+This plugin enables execution of unsecured groovy scripts on Jenkins
+master. Do not use it unless you know what you are doing.
+
+Suppressing the security put in place in several Jenkins plugins is
+discouraged though sometimes useful practice. For example, migrating
+configuration from a plugin version that allows unsecured script
+execution to the secured version. Enabling this temporarily, will not
+block on potentially unsafe signatures so they can be evaluated and
+whitelisted and the plugin can be uninstalled again.
+
+The plugin is disabled after installation. It can be enabled providing
+`-Dpermissive-script-security.enabled=true` property to Jenkins master
+JVM. Since 0.3, value **no\_security** is supported to permit not
+whitelisted signatures without any logging. Note that this is not secure
+at all.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # permissive-script-security-plugin
 Permissive Script Security Plugin
 
-Turn on permissive mode of Script Security Plugin. Problematic
+Turns on permissive mode of Script Security Plugin. Problematic
 signatures will be logged but access will not be rejected.
 
-This plugin enables execution of unsecured groovy scripts on Jenkins
+This plugin enables execution of unsecured Groovy scripts on Jenkins
 controller. Do not use it unless you know what you are doing.
 
 Suppressing the security put in place in several Jenkins plugins is
@@ -16,6 +16,5 @@ allowlisted and the plugin can be uninstalled again.
 
 The plugin is disabled after installation. It can be enabled providing
 `-Dpermissive-script-security.enabled=true` property to Jenkins controller
-JVM. Since 0.3, value **no\_security** is supported to permit not
-allowlisted signatures without any logging. Note that this is not secure
+JVM. Since 0.3, value **no\_security** is supported to permit disallowed signatures without any logging. Note that this is not secure
 at all.

--- a/README.md
+++ b/README.md
@@ -5,17 +5,17 @@ Turn on permissive mode of Script Security Plugin. Problematic
 signatures will be logged but access will not be rejected.
 
 This plugin enables execution of unsecured groovy scripts on Jenkins
-master. Do not use it unless you know what you are doing.
+controller. Do not use it unless you know what you are doing.
 
 Suppressing the security put in place in several Jenkins plugins is
 discouraged though sometimes useful practice. For example, migrating
 configuration from a plugin version that allows unsecured script
 execution to the secured version. Enabling this temporarily, will not
 block on potentially unsafe signatures so they can be evaluated and
-whitelisted and the plugin can be uninstalled again.
+allowlisted and the plugin can be uninstalled again.
 
 The plugin is disabled after installation. It can be enabled providing
-`-Dpermissive-script-security.enabled=true` property to Jenkins master
+`-Dpermissive-script-security.enabled=true` property to Jenkins controller
 JVM. Since 0.3, value **no\_security** is supported to permit not
-whitelisted signatures without any logging. Note that this is not secure
+allowlisted signatures without any logging. Note that this is not secure
 at all.

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     <packaging>hpi</packaging>
     <name>Permissive Script Security Plugin</name>
     <description>Do not install unless you know what you are doing. Turns on permissive mode of Script Security Plugin. Problematic signatures will be logged but access will not be rejected.</description>
-    <url>https://wiki.jenkins-ci.org/display/JENKINS/Permissive+Script+Security+Plugin</url>
+    <url>https://github.com/jenkinsci/permissive-script-security-plugin</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This PR copies the Permissive Script Security Plugin Readme information from the **plugins-wiki-docs** repo to the **permissive-script-security-plugin** repo and creates a new README.md file as part of the Hacktoberfest docs-to-code project.

I also changed "master" to "controller" and "whitelist" to "allowlist" per the new terminology guidelines.